### PR TITLE
General: Amend includes where applicable

### DIFF
--- a/include/jbus/Endpoint.hpp
+++ b/include/jbus/Endpoint.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
-#include "Common.hpp"
-#include "Socket.hpp"
-#include <thread>
-#include <mutex>
 #include <condition_variable>
+#include <cstddef>
+#include <functional>
+#include <mutex>
+#include <thread>
+
+#include "jbus/Common.hpp"
+#include "jbus/Socket.hpp"
 
 namespace jbus {
 

--- a/include/jbus/Listener.hpp
+++ b/include/jbus/Listener.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
-#include "Common.hpp"
-#include "Socket.hpp"
-#include <thread>
-#include <queue>
+#include <cstdint>
+#include <memory>
 #include <mutex>
+#include <queue>
+#include <thread>
+
+#include "jbus/Socket.hpp"
 
 namespace jbus {
+class Endpoint;
 
 /** Server interface for accepting incoming connections from GBA emulator instances. */
 class Listener {
@@ -33,6 +36,7 @@ public:
    *  @return Endpoint instance, ready to issue commands. */
   std::unique_ptr<Endpoint> accept();
 
+  Listener();
   ~Listener();
 };
 

--- a/include/jbus/Socket.hpp
+++ b/include/jbus/Socket.hpp
@@ -1,16 +1,13 @@
 #pragma once
 
-#include <sys/types.h>
-#include <fcntl.h>
+#include <cstddef>
+#include <cstdint>
 #include <string>
-#include <memory.h>
 
 #ifdef _WIN32
 #include <BaseTsd.h>
-typedef UINT_PTR SOCKET;
+using SOCKET = UINT_PTR;
 #endif
-
-#include "Common.hpp"
 
 struct sockaddr_in;
 

--- a/lib/Endpoint.cpp
+++ b/lib/Endpoint.cpp
@@ -1,6 +1,12 @@
 #include "jbus/Endpoint.hpp"
 
+#include <cstring>
+
 #define LOG_TRANSFER 0
+
+#if LOG_TRANSFER
+#include <cstdio>
+#endif
 
 namespace jbus {
 

--- a/lib/Listener.cpp
+++ b/lib/Listener.cpp
@@ -1,7 +1,13 @@
 #include "jbus/Listener.hpp"
+
+#include "jbus/Common.hpp"
 #include "jbus/Endpoint.hpp"
 
 #define LOG_LISTENER 0
+
+#if LOG_LISTENER
+#include <cstdio>
+#endif
 
 namespace jbus {
 
@@ -93,6 +99,8 @@ std::unique_ptr<Endpoint> Listener::accept() {
   }
   return {};
 }
+
+Listener::Listener() = default;
 
 Listener::~Listener() { stop(); }
 

--- a/lib/Socket.cpp
+++ b/lib/Socket.cpp
@@ -1,13 +1,19 @@
 #include "jbus/Socket.hpp"
 
+#include <cstdio>
+#include <cstring>
+
 #ifndef _WIN32
-#include <sys/socket.h>
+#include <cerrno>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
-#include <arpa/inet.h>
-#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
-#include <cerrno>
 #else
 #include <WinSock2.h>
 #include <Ws2tcpip.h>

--- a/lib/Socket.cpp
+++ b/lib/Socket.cpp
@@ -108,7 +108,7 @@ void Socket::setRemoteSocket(int remSocket) noexcept {
 }
 
 #ifdef _WIN32
-Socket::EResult Socket::LastWSAError() {
+Socket::EResult Socket::LastWSAError() noexcept {
   switch (WSAGetLastError()) {
   case WSAEWOULDBLOCK:
   case WSAEALREADY:


### PR DESCRIPTION
Ensures all necessary includes are specified for the relevant headers. While we're at it, we can also fix a missed noexcept specifier.