### PR TITLE
Listener: Remove unnecessary bind() within start()

### DIFF
--- a/lib/Listener.cpp
+++ b/lib/Listener.cpp
@@ -80,7 +80,7 @@ void Listener::listenerProc() {
 void Listener::start() {
   stop();
   m_running = true;
-  m_listenerThread = std::thread(std::bind(&Listener::listenerProc, this));
+  m_listenerThread = std::thread(&Listener::listenerProc, this);
 }
 
 void Listener::stop() {


### PR DESCRIPTION
std::thread already handles execution of member functions out-of-the-box.